### PR TITLE
Change recent meal plans to show only current/future plans

### DIFF
--- a/src/app/api/meal-plans/__tests__/route.test.ts
+++ b/src/app/api/meal-plans/__tests__/route.test.ts
@@ -300,6 +300,32 @@ describe('api/meal-plans route', () => {
     expect(filterArg.startDate).toEqual({ $gte: '2026-02-01', $lte: '2026-02-28' });
   });
 
+  it('GET filters by minEndDate when provided', async () => {
+    (getServerSession as any).mockResolvedValueOnce({ user: { id: 'u1' } });
+    toArrayMock.mockResolvedValueOnce([
+      {
+        _id: 'p1',
+        name: 'Current Week',
+        startDate: '2026-02-16',
+        endDate: '2026-02-22',
+        templateId: 't1',
+        templateSnapshot: { startDay: 'saturday', meals: { breakfast: true, lunch: true, dinner: true }, weeklyStaples: [] },
+        items: [],
+        createdAt: new Date()
+      },
+    ]);
+
+    const res = await routes.GET(makeReq('http://localhost/api/meal-plans?minEndDate=2026-02-21'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveLength(1);
+    expect(json[0].name).toBe('Current Week');
+
+    // Verify endDate filter was applied to MongoDB query
+    const filterArg = findMock.mock.calls[findMock.mock.calls.length - 1][0];
+    expect(filterArg.endDate).toEqual({ $gte: '2026-02-21' });
+  });
+
   it('GET returns all plans when no date filters provided', async () => {
     (getServerSession as any).mockResolvedValueOnce({ user: { id: 'u1' } });
     toArrayMock.mockResolvedValueOnce([

--- a/src/app/api/meal-plans/route.ts
+++ b/src/app/api/meal-plans/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('startDate');
     const endDate = searchParams.get('endDate');
+    const minEndDate = searchParams.get('minEndDate');
 
     const client = await getMongoClient();
     const db = client.db();
@@ -62,6 +63,11 @@ export async function GET(request: NextRequest) {
       if (startDate) dateFilter.$gte = startDate;
       if (endDate) dateFilter.$lte = endDate;
       filter.startDate = dateFilter;
+    }
+
+    // Filter by minimum endDate (e.g., to find plans that include today or future dates)
+    if (minEndDate) {
+      filter.endDate = { $gte: minEndDate };
     }
 
     // Get meal plans for current user AND shared owners

--- a/src/app/meal-plans/page.tsx
+++ b/src/app/meal-plans/page.tsx
@@ -190,14 +190,11 @@ function MealPlansPageContent() {
   const loadData = useCallback(async () => {
     try {
       setLoading(true);
-      // Fetch only recent meal plans (last 4 weeks) instead of all
-      const now = new Date();
-      const fourWeeksAgo = new Date(now);
-      fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
-      const recentStartDate = formatDateForAPI(fourWeeksAgo);
+      // Fetch current meal plans (those that include today or future dates)
+      const today = formatDateForAPI(new Date());
 
       const [plans, userTemplate, pendingInvites, invitedUsers, owners, settingsResponse] = await Promise.all([
-        fetchMealPlans({ startDate: recentStartDate }),
+        fetchMealPlans({ minEndDate: today }),
         fetchMealPlanTemplate(),
         fetchPendingMealPlanSharingInvitations(),
         fetchSharedMealPlanUsers(), // Users YOU invited
@@ -816,9 +813,9 @@ function MealPlansPageContent() {
             </Paper>
           )}
 
-          {/* Recent Meal Plans */}
+          {/* Current Meal Plans */}
           <Paper sx={{ p: 3, mb: 4, maxWidth: 'md', mx: 'auto' }}>
-            <Typography variant="h6" sx={{ mb: 2 }}>Recent Meal Plans</Typography>
+            <Typography variant="h6" sx={{ mb: 2 }}>Current Meal Plans</Typography>
 
             {loading ? (
               <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
@@ -922,7 +919,7 @@ function MealPlansPageContent() {
                   </>
                 ) : (
                   <Alert severity="info">
-                    No recent meal plans. Create your first meal plan to get started!
+                    No current meal plans. Create your first meal plan to get started!
                   </Alert>
                 )}
               </>

--- a/src/lib/meal-plan-utils.ts
+++ b/src/lib/meal-plan-utils.ts
@@ -118,10 +118,11 @@ export const updateMealPlanTemplate = async (template: UpdateMealPlanTemplateReq
 };
 
 // Meal Plans
-export const fetchMealPlans = async (opts?: { startDate?: string; endDate?: string }): Promise<MealPlanWithTemplate[]> => {
+export const fetchMealPlans = async (opts?: { startDate?: string; endDate?: string; minEndDate?: string }): Promise<MealPlanWithTemplate[]> => {
   const params = new URLSearchParams();
   if (opts?.startDate) params.set('startDate', opts.startDate);
   if (opts?.endDate) params.set('endDate', opts.endDate);
+  if (opts?.minEndDate) params.set('minEndDate', opts.minEndDate);
   const qs = params.toString();
   const response = await fetch(`/api/meal-plans${qs ? `?${qs}` : ''}`);
   if (!response.ok) {


### PR DESCRIPTION
Filter meal plans by endDate >= today instead of startDate >= 4 weeks ago,
so only plans that include the current date or future dates are shown.
Rename the section from "Recent Meal Plans" to "Current Meal Plans".

- Add minEndDate query parameter to GET /api/meal-plans
- Update fetchMealPlans utility to support minEndDate option
- Update meal plans page to use new filter logic
- Add test for minEndDate API filtering

https://claude.ai/code/session_01A8LhtkdZgBKds79MpzRdTt