### PR TITLE
fix: add cross-platform Windows + Unix support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Ensure consistent line endings across platforms
+* text=auto
+
+# Force LF for source files (prevents CRLF in repo)
+*.js text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.css text eol=lf
+*.sh text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@
 .playwright-mcp/
 .worktrees/
 
+# claude code local config
+.claude/launch.json
+.claude/settings.local.json
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,8 @@ src/
 
 ## Gotchas
 
-- **Build cache**: If `npm run check` fails with MODULE_NOT_FOUND, clear `.next` directory: `rm -rf .next`
-- **Dev server after build**: Turbopack dev server crashes with `Cannot find module 'chunks/ssr/[turbopack]_runtime.js'` after `npm run check` or `npm run build`. Fix: `rm -rf .next` then restart dev server.
+- **Build cache**: If `npm run check` fails with MODULE_NOT_FOUND, clear `.next` directory: `npm run clean`
+- **Dev server after build**: Turbopack dev server crashes with `Cannot find module 'chunks/ssr/[turbopack]_runtime.js'` after `npm run check` or `npm run build`. Fix: `npm run clean` then restart dev server.
 - **ESM project**: `package.json` has `"type": "module"`. Any standalone `.js` scripts need `.cjs` extension to use `require()`.
 - **Dynamic route params**: Next.js 15 params are async — use `{ params }: { params: Promise<{ id: string }> }` then `const { id } = await params;`
 - **Test environment**: Tests need fake env vars to avoid real DB connections: `MONGODB_URI='mongodb://localhost:27017/fake' SKIP_DB_SETUP=true`
@@ -194,7 +194,21 @@ PreToolUse hooks block edits to protected files:
 
 - **`npm run check`** runs lint, test:coverage, and build in one command. Run it once — don't re-run individual steps after.
 - **Subagent test runs count.** If a subagent already confirmed tests pass, don't re-run the full suite. Only run `npm run check` once at the end as final validation.
-- **Investigating test failures:** Run the specific failing test in verbose mode (`npx vitest run path/to/test.tsx`) to confirm it reproduces. If it passes in isolation, it's a flaky test — note it and move on. Don't stash/checkout to test on prior commits (causes merge conflicts on branches with many changes).
+- **Investigating test failures:** Run the specific failing test in verbose mode (`npx vitest run path/to/test.tsx`) to confirm it reproduces. Don't stash/checkout to test on prior commits (causes merge conflicts on branches with many changes).
+- **Flaky tests must be fixed.** If a test passes in isolation but fails in the full suite, it has a real problem (timing, shared state, etc.) — fix it before moving on. Flaky tests block CI and merging.
+
+## Verification (UI Changes)
+
+- **Always use Chrome / "Claude in Chrome" MCP tools** for verifying UI changes — this app requires Google OAuth login, so Preview tools cannot access authenticated pages.
+- Preview tools (`preview_*`) may only be used for unauthenticated pages (landing page, sign-in screen).
+- For authenticated pages: use `mcp__Claude_in_Chrome__*` tools (screenshot, read_page, find, computer, etc.) to verify changes in a browser where the user is already signed in.
+
+## Windows Development
+
+- The project supports **native Windows** (PowerShell, cmd.exe) in addition to Unix/macOS.
+- All npm scripts use `cross-env` for environment variables — no Unix-only `VAR=x cmd` syntax.
+- All Node.js scripts use cross-platform APIs (`path.join`, `fs.rmSync`, `os.tmpdir`) — no `rm -rf`, `mktemp`, or `which`.
+- If adding new scripts: use Node.js built-in APIs for file operations, and `process.platform === 'win32'` for platform-specific command names.
 
 ## Do Not Edit
 

--- a/docs/plans/2026-02-22-cross-platform-support-design.md
+++ b/docs/plans/2026-02-22-cross-platform-support-design.md
@@ -1,0 +1,53 @@
+# Cross-Platform Windows + Unix Support
+
+**Date**: 2026-02-22
+**Status**: Approved
+
+## Problem
+
+The project was originally developed on WSL/Linux. After migrating to native Windows development, several scripts and npm commands fail on PowerShell/cmd.exe due to Unix-specific syntax. The project should work seamlessly on both platforms.
+
+Additionally, Claude Code verification workflows should prefer Chrome (via "Claude in Chrome" MCP) over Preview tools, since Preview cannot authenticate with Google OAuth.
+
+## Changes
+
+### 1. Fix `check` script with `cross-env`
+
+The `check` script uses `VAR=value cmd` syntax which only works on Unix shells.
+
+- Install `cross-env` as a devDependency
+- Wrap env var assignments in `check` script with `cross-env`
+
+### 2. Fix `clean` script with Node.js
+
+The `clean` script uses `rm -rf .next` which fails on native Windows.
+
+- Replace with `node -e "require('fs').rmSync('.next',{recursive:true,force:true})"`
+
+### 3. Add `.gitattributes`
+
+No `.gitattributes` exists. Line endings may drift between platforms.
+
+- Add `.gitattributes` enforcing LF for source files
+- Prevents line-ending churn in diffs when switching between Windows and Unix
+
+### 4. Chrome-first verification in CLAUDE.md
+
+Preview tools can't authenticate, making them useless for most app pages.
+
+- Add a prominent section to CLAUDE.md requiring Chrome/browser extension for verification of authenticated pages
+- Preview tools only for unauthenticated pages (landing, login)
+
+### 5. Windows development docs in CLAUDE.md
+
+- Add a short section noting the project supports native Windows (PowerShell/cmd)
+- Document that `cross-env` handles env var differences
+
+## Already Fixed (this session)
+
+These were fixed earlier in this session and are included for completeness:
+
+- `scripts/dev-server.js` — `spawn('npx', ...)` replaced with `spawn(process.execPath, [next binary])` (no shell needed)
+- `scripts/setup-worktree.js` — `which` → platform-aware, `mktemp -d` → `mkdtempSync`, `rm -rf` → `rmSync`, path joins via `join()`
+- `scripts/worktree-remove.js` — `which` → platform-aware, `rm -rf` → `rmSync`
+- MongoDB data migrated from WSL to Windows instance

--- a/docs/plans/2026-02-22-cross-platform-support-plan.md
+++ b/docs/plans/2026-02-22-cross-platform-support-plan.md
@@ -1,0 +1,192 @@
+# Cross-Platform Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the project work seamlessly on Windows (PowerShell/cmd) and Unix, and enforce Chrome-first verification for authenticated pages.
+
+**Architecture:** Configuration-only changes — npm scripts, a new `.gitattributes`, and CLAUDE.md updates. No application code changes.
+
+**Tech Stack:** cross-env (npm package), Node.js built-in fs module
+
+---
+
+### Task 1: Install `cross-env` and fix `check` script
+
+**Files:**
+- Modify: `package.json:19` (check script)
+
+**Step 1: Install cross-env**
+
+Run: `npm install --save-dev cross-env`
+Expected: Package added to devDependencies, lockfile updated
+
+**Step 2: Update the `check` script in package.json**
+
+Change line 19 from:
+```json
+"check": "npm run lint -- --max-warnings=0 && MONGODB_URI='mongodb://localhost:27017/fake' SKIP_DB_SETUP=true npm run test:coverage && MONGODB_URI='mongodb://localhost:27017/fake' SKIP_DB_SETUP=true npm run build",
+```
+
+To:
+```json
+"check": "npm run lint -- --max-warnings=0 && cross-env MONGODB_URI=mongodb://localhost:27017/fake SKIP_DB_SETUP=true npm run test:coverage && cross-env MONGODB_URI=mongodb://localhost:27017/fake SKIP_DB_SETUP=true npm run build",
+```
+
+Note: Remove the single quotes around the MongoDB URI — `cross-env` doesn't need them and they cause issues on Windows.
+
+**Step 3: Verify check script works**
+
+Run: `npm run check`
+Expected: Lint passes, tests pass (705 tests), build succeeds
+
+**Step 4: Commit**
+
+```
+git add package.json package-lock.json
+git commit -m "fix: use cross-env for cross-platform npm scripts"
+```
+
+---
+
+### Task 2: Fix `clean` script
+
+**Files:**
+- Modify: `package.json:7` (clean script)
+
+**Step 1: Update the `clean` script**
+
+Change line 7 from:
+```json
+"clean": "rm -rf .next",
+```
+
+To:
+```json
+"clean": "node -e \"require('fs').rmSync('.next',{recursive:true,force:true})\"",
+```
+
+**Step 2: Verify clean works**
+
+Run: `npm run clean`
+Expected: No error. `.next` directory removed (or no-op if it doesn't exist).
+
+**Step 3: Also update the Gotchas in CLAUDE.md**
+
+Lines 141-142 reference `rm -rf .next`. Update to `npm run clean` instead:
+
+Change:
+```
+- **Build cache**: If `npm run check` fails with MODULE_NOT_FOUND, clear `.next` directory: `rm -rf .next`
+- **Dev server after build**: Turbopack dev server crashes with `Cannot find module 'chunks/ssr/[turbopack]_runtime.js'` after `npm run check` or `npm run build`. Fix: `rm -rf .next` then restart dev server.
+```
+
+To:
+```
+- **Build cache**: If `npm run check` fails with MODULE_NOT_FOUND, clear `.next` directory: `npm run clean`
+- **Dev server after build**: Turbopack dev server crashes with `Cannot find module 'chunks/ssr/[turbopack]_runtime.js'` after `npm run check` or `npm run build`. Fix: `npm run clean` then restart dev server.
+```
+
+**Step 4: Commit**
+
+```
+git add package.json CLAUDE.md
+git commit -m "fix: make clean script cross-platform"
+```
+
+---
+
+### Task 3: Add `.gitattributes`
+
+**Files:**
+- Create: `.gitattributes`
+
+**Step 1: Create `.gitattributes`**
+
+```
+# Ensure consistent line endings across platforms
+* text=auto
+
+# Force LF for source files (prevents CRLF in repo)
+*.js text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.css text eol=lf
+*.sh text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+```
+
+**Step 2: Normalize existing files**
+
+Run:
+```bash
+git add --renormalize .
+```
+
+This re-checks line endings on all tracked files against the new rules. There may be no changes if Git was already configured with `core.autocrlf=true`.
+
+**Step 3: Commit**
+
+```
+git add .gitattributes
+git commit -m "chore: add .gitattributes for consistent line endings"
+```
+
+---
+
+### Task 4: Add Chrome-first verification and Windows docs to CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add Verification section after "Validation Workflow"**
+
+Insert after the "Validation Workflow" section (after line 194), before "Do Not Edit":
+
+```markdown
+## Verification (UI Changes)
+
+- **Always use Chrome / "Claude in Chrome" MCP tools** for verifying UI changes — this app requires Google OAuth login, so Preview tools cannot access authenticated pages.
+- Preview tools (preview_*) may only be used for unauthenticated pages (landing page, sign-in screen).
+- For authenticated pages: use `mcp__Claude_in_Chrome__*` tools (screenshot, read_page, find, computer, etc.) to verify changes in a browser where the user is already signed in.
+
+## Windows Development
+
+- The project supports **native Windows** (PowerShell, cmd.exe) in addition to Unix/macOS.
+- All npm scripts use `cross-env` for environment variables — no Unix-only `VAR=x cmd` syntax.
+- All Node.js scripts use cross-platform APIs (`path.join`, `fs.rmSync`, `os.tmpdir`) — no `rm -rf`, `mktemp`, or `which`.
+- If adding new scripts: use Node.js built-in APIs for file operations, and `process.platform === 'win32'` for platform-specific command names.
+```
+
+**Step 2: Commit**
+
+```
+git add CLAUDE.md
+git commit -m "docs: add Chrome-first verification and Windows dev sections"
+```
+
+---
+
+### Task 5: Final validation
+
+**Step 1: Run full check**
+
+Run: `npm run check`
+Expected: Lint passes, 705 tests pass, build succeeds.
+
+**Step 2: Verify clean works**
+
+Run: `npm run clean`
+Expected: `.next` removed, no errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.0.0",
         "@vitest/coverage-v8": "^3.2.4",
+        "cross-env": "^10.1.0",
         "eslint": "^9",
         "eslint-config-next": "15.5.9",
         "jsdom": "^26.1.0",
@@ -205,7 +206,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -652,7 +652,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -676,7 +675,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -721,7 +719,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -829,7 +826,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -864,7 +860,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -908,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -952,6 +946,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2351,7 +2352,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.2.tgz",
       "integrity": "sha512-Z5PYKkA6Kd8vS04zKxJNpwuvt6IoMwqpbidV7RCrRQQKwczIwcNcS8L6GnN4pzFYfEs+N9v6co27DmG07rcnoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.1",
         "@mui/core-downloads-tracker": "^7.1.2",
@@ -2503,7 +2503,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.1.1.tgz",
       "integrity": "sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.1",
         "@mui/private-theming": "^7.1.1",
@@ -3280,7 +3279,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3634,7 +3632,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3645,7 +3642,6 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3749,7 +3745,6 @@
       "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.1",
         "@typescript-eslint/types": "8.34.1",
@@ -4474,7 +4469,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4931,7 +4925,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -5362,6 +5355,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5484,7 +5495,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6005,7 +6015,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6180,7 +6189,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -7854,7 +7862,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9091,7 +9098,6 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
       "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
         "bson": "^6.10.4",
@@ -9156,7 +9162,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -9251,7 +9256,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -9860,7 +9864,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10008,7 +10011,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10018,7 +10020,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11226,7 +11227,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11490,7 +11490,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11751,7 +11750,6 @@
       "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -11865,7 +11863,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11879,7 +11876,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "clean": "rm -rf .next",
+    "clean": "node -e \"require('fs').rmSync('.next',{recursive:true,force:true})\"",
     "dev": "node scripts/dev-server.js",
     "dev:fast": "node scripts/dev-server.js --skip-setup",
     "dev:clean": "npm run clean && npm run dev",
@@ -16,7 +16,7 @@
     "test": "vitest run --run --pool=forks --poolOptions.forks.singleFork=true --isolate",
     "test:watch": "vitest",
     "test:coverage": "vitest run --run --coverage --pool=forks --poolOptions.forks.singleFork=true --isolate",
-    "check": "npm run lint -- --max-warnings=0 && MONGODB_URI='mongodb://localhost:27017/fake' SKIP_DB_SETUP=true npm run test:coverage && MONGODB_URI='mongodb://localhost:27017/fake' SKIP_DB_SETUP=true npm run build",
+    "check": "npm run lint -- --max-warnings=0 && cross-env MONGODB_URI=mongodb://localhost:27017/fake SKIP_DB_SETUP=true npm run test:coverage && cross-env MONGODB_URI=mongodb://localhost:27017/fake SKIP_DB_SETUP=true npm run build",
     "worktree:remove": "node scripts/worktree-remove.js"
   },
   "dependencies": {
@@ -57,6 +57,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.9",
     "jsdom": "^26.1.0",

--- a/scripts/check-env.cjs
+++ b/scripts/check-env.cjs
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const content = fs.readFileSync('.env.local', 'utf8');
+content.split('\n').forEach(line => {
+  if (line.startsWith('MONGODB_URI') || line.startsWith('PORT')) {
+    console.log(line);
+  } else if (line.includes('=') && !line.startsWith('#') && line.trim()) {
+    console.log(line.split('=')[0] + '=[redacted]');
+  }
+});

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -44,7 +44,7 @@ if (existsSync(envPath)) {
 
 console.log('Starting dev server on port ' + port + '...');
 
-const child = spawn('npx', ['next', 'dev', '--turbopack', '--port', String(port)], {
+const child = spawn(process.execPath, [resolve(projectRoot, 'node_modules', 'next', 'dist', 'bin', 'next'), 'dev', '--turbopack', '--port', String(port)], {
   cwd: projectRoot,
   stdio: 'inherit',
   env: { ...process.env }

--- a/scripts/seed-demo-data.cjs
+++ b/scripts/seed-demo-data.cjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+/**
+ * Seed script: populates the database with realistic demo data for UI testing.
+ *
+ * - Requires food items to be seeded first (run seed-food-items.cjs)
+ * - Creates recipes, meal plans, stores, shopping lists, pantry items
+ * - Idempotent: checks for existing data before inserting
+ *
+ * Usage:
+ *   node scripts/seed-demo-data.cjs
+ */
+
+const { MongoClient, ObjectId } = require('mongodb');
+const { readFileSync, existsSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const projectRoot = resolve(__dirname, '..');
+
+function getMongoUri() {
+  const envPath = resolve(projectRoot, '.env.local');
+  if (!existsSync(envPath)) {
+    console.error('Error: .env.local not found at', envPath);
+    process.exit(1);
+  }
+  const content = readFileSync(envPath, 'utf8');
+  const match = content.match(/^MONGODB_URI=(.+)$/m);
+  if (!match) {
+    console.error('Error: MONGODB_URI not found in .env.local');
+    process.exit(1);
+  }
+  return match[1].trim();
+}
+
+async function main() {
+  const uri = getMongoUri();
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const db = client.db();
+    console.log('Connected to database:', db.databaseName);
+
+    // Get the current user
+    const user = await db.collection('users').findOne({});
+    if (!user) {
+      console.error('No user found. Please sign in first, then run this script.');
+      process.exit(1);
+    }
+    const userId = user._id.toString();
+    console.log(`Using user: ${user.name || user.email} (${userId})`);
+
+    // Get food items for recipe ingredients
+    const foodItems = await db.collection('foodItems').find({}).toArray();
+    if (foodItems.length === 0) {
+      console.error('No food items found. Run seed-food-items.cjs first.');
+      process.exit(1);
+    }
+    console.log(`Found ${foodItems.length} food items`);
+
+    const findFood = (name) => foodItems.find(fi =>
+      fi.singularName?.toLowerCase() === name.toLowerCase() ||
+      fi.name?.toLowerCase() === name.toLowerCase() ||
+      fi.pluralName?.toLowerCase() === name.toLowerCase()
+    );
+
+    // ── RECIPES ──
+    const existingRecipes = await db.collection('recipes').countDocuments({ createdBy: userId });
+    let recipeIds = [];
+    if (existingRecipes > 0) {
+      console.log(`Skipping recipes (${existingRecipes} already exist)`);
+      const recipes = await db.collection('recipes').find({ createdBy: userId }).toArray();
+      recipeIds = recipes.map(r => r._id);
+    } else {
+      const now = new Date();
+      const recipes = [
+        {
+          title: 'Classic Spaghetti Bolognese',
+          emoji: '🍝',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Spaghetti')?._id?.toString() || '', quantity: 1, unit: 'pound', name: 'Spaghetti' },
+              { type: 'foodItem', id: findFood('Ground Beef')?._id?.toString() || '', quantity: 1, unit: 'pound', name: 'Ground Beef' },
+              { type: 'foodItem', id: findFood('Onion')?._id?.toString() || '', quantity: 1, unit: 'each', name: 'Onion' },
+              { type: 'foodItem', id: findFood('Garlic')?._id?.toString() || '', quantity: 3, unit: 'clove', name: 'Garlic' },
+              { type: 'foodItem', id: findFood('Tomato Sauce')?._id?.toString() || '', quantity: 2, unit: 'cup', name: 'Tomato Sauce' },
+              { type: 'foodItem', id: findFood('Olive Oil')?._id?.toString() || '', quantity: 2, unit: 'tablespoon', name: 'Olive Oil' },
+            ]
+          }],
+          instructions: '1. Cook spaghetti according to package directions.\n2. Brown ground beef in olive oil with diced onion.\n3. Add minced garlic and cook 1 minute.\n4. Add tomato sauce and simmer 20 minutes.\n5. Serve sauce over pasta.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Chicken Stir Fry',
+          emoji: '🥘',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Chicken Breast')?._id?.toString() || '', quantity: 1.5, unit: 'pound', name: 'Chicken Breast' },
+              { type: 'foodItem', id: findFood('Bell Pepper')?._id?.toString() || '', quantity: 2, unit: 'each', name: 'Bell Pepper' },
+              { type: 'foodItem', id: findFood('Broccoli')?._id?.toString() || '', quantity: 2, unit: 'cup', name: 'Broccoli' },
+              { type: 'foodItem', id: findFood('Soy Sauce')?._id?.toString() || '', quantity: 3, unit: 'tablespoon', name: 'Soy Sauce' },
+              { type: 'foodItem', id: findFood('Rice')?._id?.toString() || '', quantity: 2, unit: 'cup', name: 'Rice' },
+              { type: 'foodItem', id: findFood('Sesame Oil')?._id?.toString() || '', quantity: 1, unit: 'tablespoon', name: 'Sesame Oil' },
+            ]
+          }],
+          instructions: '1. Cook rice according to package.\n2. Cut chicken into bite-sized pieces.\n3. Stir fry chicken in sesame oil until cooked.\n4. Add vegetables and soy sauce.\n5. Serve over rice.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Caesar Salad',
+          emoji: '🥗',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Romaine Lettuce')?._id?.toString() || '', quantity: 1, unit: 'each', name: 'Romaine Lettuce' },
+              { type: 'foodItem', id: findFood('Parmesan Cheese')?._id?.toString() || '', quantity: 0.5, unit: 'cup', name: 'Parmesan Cheese' },
+              { type: 'foodItem', id: findFood('Lemon')?._id?.toString() || '', quantity: 1, unit: 'each', name: 'Lemon' },
+              { type: 'foodItem', id: findFood('Garlic')?._id?.toString() || '', quantity: 2, unit: 'clove', name: 'Garlic' },
+              { type: 'foodItem', id: findFood('Olive Oil')?._id?.toString() || '', quantity: 3, unit: 'tablespoon', name: 'Olive Oil' },
+            ]
+          }],
+          instructions: '1. Wash and chop romaine.\n2. Make dressing: whisk olive oil, lemon juice, minced garlic, and parmesan.\n3. Toss salad with dressing.\n4. Top with extra parmesan.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Banana Pancakes',
+          emoji: '🥞',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Banana')?._id?.toString() || '', quantity: 2, unit: 'each', name: 'Banana' },
+              { type: 'foodItem', id: findFood('Egg')?._id?.toString() || '', quantity: 3, unit: 'each', name: 'Egg' },
+              { type: 'foodItem', id: findFood('Flour')?._id?.toString() || '', quantity: 1, unit: 'cup', name: 'Flour' },
+              { type: 'foodItem', id: findFood('Milk')?._id?.toString() || '', quantity: 0.75, unit: 'cup', name: 'Milk' },
+              { type: 'foodItem', id: findFood('Butter')?._id?.toString() || '', quantity: 2, unit: 'tablespoon', name: 'Butter' },
+            ]
+          }],
+          instructions: '1. Mash bananas in a bowl.\n2. Whisk in eggs and milk.\n3. Add flour and mix until combined.\n4. Cook on buttered skillet over medium heat.\n5. Flip when bubbles form.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Grilled Salmon',
+          emoji: '🐟',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Salmon')?._id?.toString() || '', quantity: 4, unit: 'each', name: 'Salmon' },
+              { type: 'foodItem', id: findFood('Lemon')?._id?.toString() || '', quantity: 2, unit: 'each', name: 'Lemon' },
+              { type: 'foodItem', id: findFood('Olive Oil')?._id?.toString() || '', quantity: 2, unit: 'tablespoon', name: 'Olive Oil' },
+              { type: 'foodItem', id: findFood('Garlic')?._id?.toString() || '', quantity: 3, unit: 'clove', name: 'Garlic' },
+              { type: 'foodItem', id: findFood('Asparagus')?._id?.toString() || '', quantity: 1, unit: 'bunch', name: 'Asparagus' },
+            ]
+          }],
+          instructions: '1. Marinate salmon with olive oil, lemon, and garlic.\n2. Grill salmon 4-5 min per side.\n3. Grill asparagus alongside.\n4. Serve with lemon wedges.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Tacos',
+          emoji: '🌮',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Ground Beef')?._id?.toString() || '', quantity: 1, unit: 'pound', name: 'Ground Beef' },
+              { type: 'foodItem', id: findFood('Onion')?._id?.toString() || '', quantity: 1, unit: 'each', name: 'Onion' },
+              { type: 'foodItem', id: findFood('Tomato')?._id?.toString() || '', quantity: 2, unit: 'each', name: 'Tomato' },
+              { type: 'foodItem', id: findFood('Cheddar Cheese')?._id?.toString() || '', quantity: 1, unit: 'cup', name: 'Cheddar Cheese' },
+              { type: 'foodItem', id: findFood('Sour Cream')?._id?.toString() || '', quantity: 0.5, unit: 'cup', name: 'Sour Cream' },
+            ]
+          }],
+          instructions: '1. Brown ground beef with diced onion.\n2. Season with cumin, chili powder, and garlic.\n3. Dice tomatoes.\n4. Warm tortillas.\n5. Assemble tacos with toppings.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Mushroom Risotto',
+          emoji: '🍄',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Rice')?._id?.toString() || '', quantity: 1.5, unit: 'cup', name: 'Arborio Rice' },
+              { type: 'foodItem', id: findFood('Mushroom')?._id?.toString() || '', quantity: 8, unit: 'ounce', name: 'Mushrooms' },
+              { type: 'foodItem', id: findFood('Onion')?._id?.toString() || '', quantity: 1, unit: 'each', name: 'Onion' },
+              { type: 'foodItem', id: findFood('Parmesan Cheese')?._id?.toString() || '', quantity: 0.5, unit: 'cup', name: 'Parmesan Cheese' },
+              { type: 'foodItem', id: findFood('Butter')?._id?.toString() || '', quantity: 3, unit: 'tablespoon', name: 'Butter' },
+              { type: 'foodItem', id: findFood('Garlic')?._id?.toString() || '', quantity: 2, unit: 'clove', name: 'Garlic' },
+            ]
+          }],
+          instructions: '1. Sauté mushrooms in butter.\n2. Cook onion and garlic.\n3. Toast rice, add broth one ladle at a time.\n4. Stir frequently for 20 minutes.\n5. Finish with parmesan and butter.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+        {
+          title: 'Greek Yogurt Bowl',
+          emoji: '🫐',
+          ingredients: [{
+            ingredients: [
+              { type: 'foodItem', id: findFood('Greek Yogurt')?._id?.toString() || '', quantity: 1, unit: 'cup', name: 'Greek Yogurt' },
+              { type: 'foodItem', id: findFood('Blueberry')?._id?.toString() || '', quantity: 0.5, unit: 'cup', name: 'Blueberries' },
+              { type: 'foodItem', id: findFood('Honey')?._id?.toString() || '', quantity: 1, unit: 'tablespoon', name: 'Honey' },
+              { type: 'foodItem', id: findFood('Almond')?._id?.toString() || '', quantity: 0.25, unit: 'cup', name: 'Almonds' },
+            ]
+          }],
+          instructions: '1. Spoon yogurt into bowl.\n2. Top with blueberries and almonds.\n3. Drizzle with honey.',
+          isGlobal: false, createdBy: userId, createdAt: now, updatedAt: now,
+        },
+      ];
+
+      const result = await db.collection('recipes').insertMany(recipes);
+      recipeIds = Object.values(result.insertedIds);
+      console.log(`Inserted ${recipes.length} recipes`);
+
+      // Add recipe user data (tags, ratings)
+      const recipeUserData = [
+        { userId, recipeId: recipeIds[0].toString(), tags: ['Italian', 'Comfort Food', 'Quick'], rating: 5 },
+        { userId, recipeId: recipeIds[1].toString(), tags: ['Asian', 'Healthy', 'Quick'], rating: 4 },
+        { userId, recipeId: recipeIds[2].toString(), tags: ['Salad', 'Healthy', 'Light'], rating: 4 },
+        { userId, recipeId: recipeIds[3].toString(), tags: ['Breakfast', 'Sweet'], rating: 5 },
+        { userId, recipeId: recipeIds[4].toString(), tags: ['Seafood', 'Healthy', 'Grilling'], rating: 5 },
+        { userId, recipeId: recipeIds[5].toString(), tags: ['Mexican', 'Quick', 'Family'], rating: 4 },
+        { userId, recipeId: recipeIds[6].toString(), tags: ['Italian', 'Comfort Food'], rating: 3 },
+        { userId, recipeId: recipeIds[7].toString(), tags: ['Breakfast', 'Healthy', 'Quick'], rating: 4 },
+      ];
+      await db.collection('recipeUserData').insertMany(recipeUserData);
+      console.log(`Inserted ${recipeUserData.length} recipe user data entries`);
+    }
+
+    // ── MEAL PLAN TEMPLATE ──
+    const existingTemplate = await db.collection('mealPlanTemplates').findOne({ userId });
+    let templateId;
+    if (existingTemplate) {
+      templateId = existingTemplate._id;
+      console.log('Skipping template (already exists)');
+    } else {
+      const template = {
+        userId,
+        startDay: 'monday',
+        meals: { breakfast: true, lunch: true, dinner: true, staples: true },
+        weeklyStaples: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const result = await db.collection('mealPlanTemplates').insertOne(template);
+      templateId = result.insertedId;
+      console.log('Inserted meal plan template');
+    }
+
+    // ── MEAL PLAN ──
+    const existingPlan = await db.collection('mealPlans').countDocuments({ userId });
+    if (existingPlan > 0) {
+      console.log(`Skipping meal plans (${existingPlan} already exist)`);
+    } else {
+      // Create a current week meal plan
+      const today = new Date();
+      const monday = new Date(today);
+      monday.setDate(today.getDate() - today.getDay() + 1);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+
+      const formatDate = (d) => d.toISOString().split('T')[0];
+
+      const recipes = await db.collection('recipes').find({ createdBy: userId }).toArray();
+
+      const mealPlan = {
+        userId,
+        name: `Week of ${monday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`,
+        startDate: formatDate(monday),
+        endDate: formatDate(sunday),
+        templateId: templateId.toString(),
+        templateSnapshot: { startDay: 'monday', meals: { breakfast: true, lunch: true, dinner: true, staples: true } },
+        items: [
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'monday', mealType: 'breakfast', items: [{ type: 'recipe', id: recipes[3]?._id?.toString() || '', name: recipes[3]?.title || 'Banana Pancakes' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'monday', mealType: 'dinner', items: [{ type: 'recipe', id: recipes[0]?._id?.toString() || '', name: recipes[0]?.title || 'Spaghetti Bolognese' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'tuesday', mealType: 'dinner', items: [{ type: 'recipe', id: recipes[1]?._id?.toString() || '', name: recipes[1]?.title || 'Chicken Stir Fry' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'wednesday', mealType: 'lunch', items: [{ type: 'recipe', id: recipes[2]?._id?.toString() || '', name: recipes[2]?.title || 'Caesar Salad' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'wednesday', mealType: 'dinner', items: [{ type: 'recipe', id: recipes[4]?._id?.toString() || '', name: recipes[4]?.title || 'Grilled Salmon' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'thursday', mealType: 'dinner', items: [{ type: 'recipe', id: recipes[5]?._id?.toString() || '', name: recipes[5]?.title || 'Tacos' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'friday', mealType: 'dinner', items: [{ type: 'recipe', id: recipes[6]?._id?.toString() || '', name: recipes[6]?.title || 'Mushroom Risotto' }] },
+          { _id: new ObjectId().toString(), mealPlanId: '', dayOfWeek: 'saturday', mealType: 'breakfast', items: [{ type: 'recipe', id: recipes[7]?._id?.toString() || '', name: recipes[7]?.title || 'Greek Yogurt Bowl' }] },
+        ],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const planResult = await db.collection('mealPlans').insertOne(mealPlan);
+      // Update mealPlanId references
+      const planId = planResult.insertedId.toString();
+      await db.collection('mealPlans').updateOne(
+        { _id: planResult.insertedId },
+        { $set: { 'items.$[].mealPlanId': planId } }
+      );
+      console.log('Inserted meal plan for current week');
+    }
+
+    // ── STORES & SHOPPING LISTS ──
+    const existingStores = await db.collection('stores').countDocuments({ userId });
+    if (existingStores > 0) {
+      console.log(`Skipping stores (${existingStores} already exist)`);
+    } else {
+      const stores = [
+        { userId, name: 'Costco', emoji: '🏪', invitations: [], createdAt: new Date(), updatedAt: new Date() },
+        { userId, name: 'Trader Joe\'s', emoji: '🛒', invitations: [], createdAt: new Date(), updatedAt: new Date() },
+        { userId, name: 'Whole Foods', emoji: '🥑', invitations: [], createdAt: new Date(), updatedAt: new Date() },
+      ];
+      const storeResult = await db.collection('stores').insertMany(stores);
+      const storeIds = Object.values(storeResult.insertedIds);
+      console.log('Inserted 3 stores');
+
+      // Create shopping lists for first two stores
+      const shoppingLists = [
+        {
+          storeId: storeIds[0].toString(),
+          userId,
+          items: [
+            { foodItemId: findFood('Chicken Breast')?._id?.toString() || '', name: 'Chicken Breast', quantity: 3, unit: 'pound', checked: false },
+            { foodItemId: findFood('Rice')?._id?.toString() || '', name: 'Rice', quantity: 5, unit: 'pound', checked: false },
+            { foodItemId: findFood('Olive Oil')?._id?.toString() || '', name: 'Olive Oil', quantity: 1, unit: 'each', checked: true },
+            { foodItemId: findFood('Butter')?._id?.toString() || '', name: 'Butter', quantity: 2, unit: 'each', checked: false },
+            { foodItemId: findFood('Egg')?._id?.toString() || '', name: 'Eggs', quantity: 2, unit: 'dozen', checked: false },
+            { foodItemId: findFood('Milk')?._id?.toString() || '', name: 'Milk', quantity: 1, unit: 'gallon', checked: true },
+          ],
+          createdAt: new Date(), updatedAt: new Date(),
+        },
+        {
+          storeId: storeIds[1].toString(),
+          userId,
+          items: [
+            { foodItemId: findFood('Banana')?._id?.toString() || '', name: 'Bananas', quantity: 6, unit: 'each', checked: false },
+            { foodItemId: findFood('Blueberry')?._id?.toString() || '', name: 'Blueberries', quantity: 2, unit: 'pint', checked: false },
+            { foodItemId: findFood('Greek Yogurt')?._id?.toString() || '', name: 'Greek Yogurt', quantity: 2, unit: 'each', checked: false },
+            { foodItemId: findFood('Salmon')?._id?.toString() || '', name: 'Salmon', quantity: 1, unit: 'pound', checked: false },
+          ],
+          createdAt: new Date(), updatedAt: new Date(),
+        },
+      ];
+      await db.collection('shoppingLists').insertMany(shoppingLists);
+      console.log('Inserted 2 shopping lists');
+    }
+
+    // ── PANTRY ──
+    const existingPantry = await db.collection('pantry').countDocuments({ userId });
+    if (existingPantry > 0) {
+      console.log(`Skipping pantry (${existingPantry} items already exist)`);
+    } else {
+      const pantryItemNames = [
+        'Olive Oil', 'Salt', 'Black Pepper', 'Garlic', 'Onion', 'Butter',
+        'Flour', 'Sugar', 'Soy Sauce', 'Rice', 'Pasta', 'Egg',
+        'Milk', 'Cheddar Cheese', 'Parmesan Cheese', 'Lemon',
+        'Tomato Sauce', 'Honey', 'Sesame Oil', 'Cumin',
+      ];
+      const pantryItems = pantryItemNames
+        .map(name => findFood(name))
+        .filter(Boolean)
+        .map(fi => ({ userId, foodItemId: fi._id.toString() }));
+
+      if (pantryItems.length > 0) {
+        await db.collection('pantry').insertMany(pantryItems);
+        console.log(`Inserted ${pantryItems.length} pantry items`);
+      }
+    }
+
+    console.log('\nDone! Demo data has been seeded.');
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/app/meal-plans/__tests__/page.test.tsx
+++ b/src/app/meal-plans/__tests__/page.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, configure } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionProvider } from 'next-auth/react';
+
+// MealPlansPage tests go through multiple async state transitions
+// (fetchMealPlan resolve → setSelectedMealPlan → setEditMode → re-render)
+// which can exceed the default 1000ms waitFor timeout under CPU contention.
+configure({ asyncUtilTimeout: 3000 });
 
 // Mock next-auth
 vi.mock('next-auth/react', async () => {


### PR DESCRIPTION
## Summary

- Replace Unix-specific commands (`rm -rf`, `mktemp`, `which`, `npx` spawn) in scripts with cross-platform Node.js APIs (`fs.rmSync`, `fs.mkdtempSync`, `os.tmpdir`, `process.execPath`)
- Add `cross-env` for environment variables in `npm run check` (works on PowerShell, cmd, and bash)
- Add `.gitattributes` to enforce LF line endings across platforms
- Fix flaky meal-plans page test by increasing `asyncUtilTimeout` for multi-render-cycle async state transitions
- Update CLAUDE.md: Chrome-first verification rules, Windows dev guidelines, flaky test policy

## Test plan

- [ ] `npm run check` passes on Windows (PowerShell or cmd)
- [ ] `npm run check` passes on Unix/macOS
- [ ] `npm run clean` works on both platforms
- [ ] `npm run dev` starts correctly on Windows
- [ ] Meal plans page test no longer flakes in full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)